### PR TITLE
Converter tool and changing version to 1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.o
+fmlrc
+fmlrc-convert

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,17 @@ SOURCES=alignment_util.cpp base_bwt.cpp bit_array.cpp csa_bwt.cpp file_iterators
 OBJECTS=$(SOURCES:.cpp=.o)
 EXECUTABLE=fmlrc
 
-all: $(SOURCES) $(EXECUTABLE)
-    
+CON_SOURCES=converter/converter_main.cpp
+CON_OBJECTS=$(CON_SOURCES:.cpp=.o)
+CON_EXEC=fmlrc-convert
+
+all: $(EXECUTABLE) $(CON_EXEC)
+
 $(EXECUTABLE): $(OBJECTS) 
 	$(CC) $(LDFLAGS) $(OBJECTS) -o $@
+
+$(CON_EXEC): $(CON_OBJECTS)
+	$(CC) $(LDFLAGS) $(CON_OBJECTS) -o $@
 
 .cpp.o:
 	$(CC) -c $(CFLAGS) $< -o $@

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ Both implementation handle parallelization by distributing the reads across all 
 ## Quick-start
 A full example is available in the `examples` subfolder.  Please refer to the [README](https://github.com/holtjma/fmlrc/blob/converter-tool/example/README.md) for directions.
 
-Additional information can be found in the quick start guide on the [FMLRC wiki](https://github.com/holtjma/fmlrc/wiki/Quick-start-test).
-
 ## Installation and Setup
 First, download the latest version of FMLRC and unzip it.  Then simply make the program and run it with the "-h" option to verify it installed.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ The second implementation is more similar to a traditional sampled FM-index that
 Both implementation handle parallelization by distributing the reads across all available threads.
 
 ## Quick-start
-A quick start guide with test data is available on the [FMLRC wiki](https://github.com/holtjma/fmlrc/wiki/Quick-start-test).
+A full example is available in the `examples` subfolder.  Please refer to the [README](https://github.com/holtjma/fmlrc/blob/converter-tool/example/README.md) for directions.
+
+Additional information can be found in the quick start guide on the [FMLRC wiki](https://github.com/holtjma/fmlrc/wiki/Quick-start-test).
 
 ## Installation and Setup
 First, download the latest version of FMLRC and unzip it.  Then simply make the program and run it with the "-h" option to verify it installed.
@@ -24,7 +26,7 @@ First, download the latest version of FMLRC and unzip it.  Then simply make the 
 ## Building the short-read BWT
 Prior to running FMLRC, a BWT of the short-read sequencing data needs to be constructed.
 Currently, the implementation expects it to be in the Run-Length Encoded (RLE) format of the [*msbwt*](https://github.com/holtjma/msbwt) python package.
-We recommend building the BWT using [*ropebwt2*](https://github.com/lh3/ropebwt2) by following the instructions on [Converting to Run-Length Encoded (RLE) format](https://github.com/holtjma/msbwt/wiki/Converting-to-msbwt's-RLE-format).
+We recommend building the BWT using [*ropebwt2*](https://github.com/lh3/ropebwt2) by following the instructions on [Converting to the fmlrc RLE-BWT format](https://github.com/holtjma/fmlrc/wiki/Converting-to-the-fmlrc-RLE-BWT-format).
 Alternatively, the *msbwt* package can directly build these BWTs ([Constructing the BWT wiki](https://github.com/holtjma/msbwt/wiki/Constructing-the-MSBWT)), but it may be slower and less memory efficient.
 
 ## Running FMLRC

--- a/converter/converter_main.cpp
+++ b/converter/converter_main.cpp
@@ -1,0 +1,54 @@
+
+//C headers
+#include <stdio.h>
+#include <unistd.h>
+
+//C++ headers
+#include <string>
+
+struct Parameters {
+    bool USE_STDIN;
+    std::string filename;
+};
+
+const std::string VERSION = "1.0.0";
+
+int main(int argc, char* argv[]) {
+    
+    //////////////////////////////////////////////////////////
+    //DEFAULT PARAMETERS
+    Parameters myParams;
+    myParams.USE_STDIN = true;              //if true, we will read all input from stdin
+    myParams.filename = "";                 //if the previous parameter is false, this is the filename we are reading from
+    //////////////////////////////////////////////////////////
+    
+    char opt;
+    bool helpRequest = false;
+    while((opt = getopt(argc, argv, "hvf:")) != -1) {
+        if(opt == 'h') helpRequest = true;
+        else if(opt == 'v') {
+            printf("fmlrc-convert version %s\n", VERSION.c_str());
+            return 0;
+        }
+        else if(opt == 'f') {
+            myParams.USE_STDIN = false;
+            myParams.filename = optarg;
+        }
+        else printf("UNHANDLED OPTION: %d %c %s\n", optind, opt, optarg);
+    }
+
+    if(helpRequest) {
+        printf("Usage:   fmlrc-convert [options]\n");
+        printf("Options: -h        print help menu\n");
+        printf("         -v        print version number and exit\n");
+        printf("         -f STR    the plain text BWT file to be converted into msbwt format (default: stdin)\n");
+        return 0;
+    }
+
+    if(myParams.USE_STDIN) {
+        printf("Using stdin\n");
+    }
+    else {
+        printf("filename: %s\n", myParams.filename.c_str());
+    }
+}

--- a/converter/converter_main.cpp
+++ b/converter/converter_main.cpp
@@ -2,53 +2,195 @@
 //C headers
 #include <stdio.h>
 #include <unistd.h>
+#include <sys/stat.h>
 
 //C++ headers
+#include <algorithm>
 #include <string>
+#include <sstream>
 
 struct Parameters {
+    bool FORCE_OVERWRITE;
     bool USE_STDIN;
     std::string filename;
 };
 
 const std::string VERSION = "1.0.0";
 
+int runConverter(Parameters myParams, char * outFN) {
+    FILE * inputStream;
+    if(myParams.USE_STDIN) {
+        inputStream = stdin;
+    }
+    else {
+        inputStream = fopen(myParams.filename.c_str(), "r");
+    }
+
+    FILE * outputStream = fopen(outFN, "w+");
+
+    //TODO: lots of header related items
+    unsigned long BUFFER_SIZE = 1024;
+    unsigned char buffer[BUFFER_SIZE]; 
+
+    //most of the files I've seen are 80 and '\x46', I'm increasing it just in case
+    unsigned long headerSize = 96;
+    std::string headerHex = "\x56";
+    unsigned long x;
+    for(x=0; x < headerSize-1; x++) {
+        buffer[x] = 32; //hex value 20 = ' '
+    }
+    buffer[headerSize-1] = 10; //hex value 0a = '\n'
+    fwrite(buffer, 1, headerSize, outputStream);
+    
+    //set up the translation, default is 255
+    unsigned char translator[256];
+    std::fill_n(translator, 256, 255);
+
+    std::string validSymbols = "$ACGNT";
+    x = 0;
+    for(char &c: validSymbols) {
+        translator[(unsigned char)c] = x;
+        x++;
+    }
+
+    //first read
+    unsigned long readBytes = fread(buffer, 1, BUFFER_SIZE, inputStream);
+
+    unsigned char currSym = buffer[0];
+    unsigned long currCount = 0;
+    unsigned char writeByte;
+    unsigned long bytesWritten = 0;
+
+    //core loop
+    while(readBytes > 0) {
+        for(x = 0; x < readBytes; x++) {
+            if(currSym == buffer[x]) {
+                currCount++;
+            }
+            else {
+                //check for invalid character; if it's the new line symbol, we will ignore it
+                if(translator[currSym] == 255) {
+                    if(currSym != 10){
+                        printf("UNEXPECTED SYMBOL DETECTED: char: \"%c\", hex: \"%x\"\n", currSym, currSym);
+                        return 1;
+                    }
+                }
+                else {
+                    //we are at the end of the run so handle it
+                    while(currCount > 0) {
+                        writeByte = translator[currSym] | ((currCount & 0x1F) << 3);
+                        fwrite(&writeByte, 1, 1, outputStream);
+                        currCount = currCount >> 5;
+                        bytesWritten += 1;
+                    }
+                        
+                    //get the next symbol since it's valid and start a new run
+                    currSym = buffer[x];
+                    currCount = 1;
+                }
+            }
+        }
+        
+        //get the next batch to parse through
+        readBytes = fread(buffer, 1, BUFFER_SIZE, inputStream);
+    }
+
+    //handle the last run
+    if(translator[currSym] == 255){
+        if(currSym != 10){
+            printf("UNEXPECTED SYMBOL DETECTED: char: \"%c\", hex: \"%x\"\n", currSym, currSym);
+            return 1;
+        }
+    }
+    else {
+        //we are at the end of the last run so handle it
+        while(currCount > 0) {
+            writeByte = translator[currSym] | ((currCount & 0x1F) << 3);
+            fwrite(&writeByte, 1, 1, outputStream);
+            currCount = currCount >> 5;
+            bytesWritten += 1;
+        }
+            
+        //clear these
+        currSym = 0;
+        currCount = 0;
+    }
+
+    //we have finished the compression part, close the input file
+    fclose(inputStream);
+    
+    //now that we know the total length, fill in the bytes for our header
+    //char initialWrite[headerSize];
+    //sprintf(initialWrite, "\x93NUMPY\x01\x00%s\x00{\'descr\': \'|u1\', \'fortran_order\': False, \'shape\': (%d,), }", headerHex.c_str(), bytesWritten);
+    //std::ostringstream stringStream;
+    //stringStream << "\x93NUMPY\x01\x00" << headerHex << "\x00{\'descr\': \'|u1\', \'fortran_order\': False, \'shape\': (" << bytesWritten << ",), }";
+    //std::string initialWrite = stringStream.str();
+
+    //have to do some special things due to the \x00 characters; might be a better way to do this
+    std::string initialWrite = "\x93NUMPY\x01";
+    initialWrite.push_back('\0');
+    initialWrite.push_back(headerHex.c_str()[0]);
+    initialWrite.push_back('\0');
+    initialWrite += "{\'descr\': \'|u1\', \'fortran_order\': False, \'shape\': (";
+    initialWrite += std::to_string(bytesWritten);
+    initialWrite += ",), }";
+
+    fseek(outputStream, 0, SEEK_SET);
+    fwrite(initialWrite.c_str(), 1, initialWrite.length(), outputStream);
+    printf("init write len: %lu\n", initialWrite.length());
+    //finally close it all out
+    fclose(outputStream);
+    
+    return 0;
+}
+
 int main(int argc, char* argv[]) {
     
     //////////////////////////////////////////////////////////
     //DEFAULT PARAMETERS
     Parameters myParams;
+    myParams.FORCE_OVERWRITE = false;       //if true, this will silently overwrite the output file if it exists
     myParams.USE_STDIN = true;              //if true, we will read all input from stdin
     myParams.filename = "";                 //if the previous parameter is false, this is the filename we are reading from
     //////////////////////////////////////////////////////////
     
     char opt;
     bool helpRequest = false;
-    while((opt = getopt(argc, argv, "hvf:")) != -1) {
+    while((opt = getopt(argc, argv, "hvfi:")) != -1) {
         if(opt == 'h') helpRequest = true;
         else if(opt == 'v') {
             printf("fmlrc-convert version %s\n", VERSION.c_str());
             return 0;
         }
-        else if(opt == 'f') {
+        else if(opt == 'i') {
             myParams.USE_STDIN = false;
             myParams.filename = optarg;
-        }
+        }else if (opt == 'f') myParams.FORCE_OVERWRITE = true;
         else printf("UNHANDLED OPTION: %d %c %s\n", optind, opt, optarg);
     }
 
-    if(helpRequest) {
-        printf("Usage:   fmlrc-convert [options]\n");
+    if(argc-optind < 1 || helpRequest) {
+        printf("Usage:   fmlrc-convert [options] <out_comp_mbswt.npy>\n");
         printf("Options: -h        print help menu\n");
         printf("         -v        print version number and exit\n");
-        printf("         -f STR    the plain text BWT file to be converted into msbwt format (default: stdin)\n");
+        printf("         -f        force overwrite of existing file (default: false)\n");
+        printf("         -i STR    the plain text BWT file to be converted into msbwt format (default: stdin)\n");
         return 0;
     }
 
-    if(myParams.USE_STDIN) {
-        printf("Using stdin\n");
+    //Input error checking
+    char * bwtFN = argv[optind];
+    struct stat buffer;
+    if(!myParams.FORCE_OVERWRITE && stat(bwtFN, &buffer) == 0) {
+        printf("ERROR: output file already exists, use -f to force overwrite\n");
+        return 1;
     }
-    else {
-        printf("filename: %s\n", myParams.filename.c_str());
+
+    if(!myParams.USE_STDIN && stat(myParams.filename.c_str(), &buffer) != 0) {
+        printf("ERROR: input filename does not exist\n");
+        return 1;
     }
+
+    //lets do the things
+    return runConverter(myParams, bwtFN);
 }

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,20 @@
+# Examples
+
+## Run _E. coli_ Example
+### Commands
+1. Go to a directory to store fmlrc and clone this repository:
+```bash
+git clone https://github.com/holtjma/fmlrc.git
+```
+2. Change into the fmlrc examples directory:
+```bash
+cd fmlrc/examples
+```
+3. Run the examples script.  This will automatically install ropebwt2 to a local path, download short- and long-read _E. coli_ data, build the multi-string BWT using ropebwt2 and fmlrc-convert, and lastly run use fmlrc to correct the first 400 reads in the long-read data:
+```bash
+./run_example.sh
+```
+
+### Outputs
+1. `./ecoli_comp_msbwt.npy` - this contains the run-length encoded multi-string BWT using the same encoding as the [msbwt](https://github.com/holtjma/msbwt) python package.  Note: if you wish to use this with msbwt, it will need to be placed in it's own directory and renamed to `comp_msbwt.npy` in that directory.  For more information, please refer to the msbwt wiki pages.
+2. `./corrected_final.fa` - this contains the first 400 long reads after correction using fmlrc.

--- a/example/README.md
+++ b/example/README.md
@@ -1,5 +1,4 @@
 # Examples
-
 ## Run _E. coli_ Example
 ### Commands
 1. Go to a directory to store fmlrc and clone this repository:

--- a/example/run_example.sh
+++ b/example/run_example.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#Download this script via "git clone https://github.com/holtjma/fmlrc.git"
+#Download this repository via "git clone https://github.com/holtjma/fmlrc.git"
 #cd to "fmlrc/examples" and run "./run_example.sh"
 
 #download and build ropebwt2
@@ -13,27 +13,32 @@ if [ ! -f ../fmlrc ]; then
     cd ..; make; cd example
 fi
 
-#download short-read ecoli
-if [ ! -f s_6_1.fastq.gz ]; then
-    curl -o s_6_1.fastq.gz http://spades.bioinf.spbau.ru/spades_test_datasets/ecoli_mc/s_6_1.fastq.gz
+DATADIR="example1"
+if [ ! -d ${DATADIR} ]; then
+    mkdir ${DATADIR}
 fi
-if [ ! -f s_6_2.fastq.gz ]; then
-    curl -o s_6_2.fastq.gz http://spades.bioinf.spbau.ru/spades_test_datasets/ecoli_mc/s_6_2.fastq.gz
+
+#download short-read ecoli
+if [ ! -f ${DATADIR}/s_6_1.fastq.gz ]; then
+    curl -o ${DATADIR}/s_6_1.fastq.gz http://spades.bioinf.spbau.ru/spades_test_datasets/ecoli_mc/s_6_1.fastq.gz
+fi
+if [ ! -f ${DATADIR}/s_6_2.fastq.gz ]; then
+    curl -o ${DATADIR}/s_6_2.fastq.gz http://spades.bioinf.spbau.ru/spades_test_datasets/ecoli_mc/s_6_2.fastq.gz
 fi
 
 #download long-read ecoli and convert to fasta format
-if [ ! -f PacBioCLR/PacBio_10kb_CLR.fasta ]; then
-    curl -o Ecoli_MG1655_pacBioToCA.tgz http://files.pacb.com/datasets/secondary-analysis/e-coli-k12-de-novo/1.3.0/Ecoli_MG1655_pacBioToCA.tgz
-    tar -xvzf Ecoli_MG1655_pacBioToCA.tgz
-    awk 'NR%4==1||NR%4==2' ./PacBioCLR/PacBio_10kb_CLR.fastq | tr "@" ">" > ./PacBioCLR/PacBio_10kb_CLR.fasta
+if [ ! -f ${DATADIR}/PacBioCLR/PacBio_10kb_CLR.fasta ]; then
+    curl -o ${DATADIR}/Ecoli_MG1655_pacBioToCA.tgz http://files.pacb.com/datasets/secondary-analysis/e-coli-k12-de-novo/1.3.0/Ecoli_MG1655_pacBioToCA.tgz
+    tar -xvzf ${DATADIR}/Ecoli_MG1655_pacBioToCA.tgz -C ${DATADIR}
+    awk 'NR%4==1||NR%4==2' ${DATADIR}/PacBioCLR/PacBio_10kb_CLR.fastq | tr "@" ">" > ${DATADIR}/PacBioCLR/PacBio_10kb_CLR.fasta
 fi
 
 #build the bwt
-if [ ! -f ./ecoli_comp_msbwt.npy ]; then
+if [ ! -f ${DATADIR}/ecoli_comp_msbwt.npy ]; then
     mkdir temp
-    gunzip -c s_6_?.fastq.gz | awk "NR % 4 == 2" | sort -T ./temp | tr NT TN | ./ropebwt2/ropebwt2 -LR | tr NT TN | ../fmlrc-convert ./ecoli_comp_msbwt.npy
+    gunzip -c ${DATADIR}/s_6_?.fastq.gz | awk "NR % 4 == 2" | sort -T ./temp | tr NT TN | ./ropebwt2/ropebwt2 -LR | tr NT TN | ../fmlrc-convert ${DATADIR}/ecoli_comp_msbwt.npy
 fi
 
 #run fmlrc
 NUM_PROCS=4
-../fmlrc -p $NUM_PROCS -e 400 ./ecoli_comp_msbwt.npy ./PacBioCLR/PacBio_10kb_CLR.fasta ./corrected_final.fa
+../fmlrc -p $NUM_PROCS -e 400 ${DATADIR}/ecoli_comp_msbwt.npy ${DATADIR}/PacBioCLR/PacBio_10kb_CLR.fasta ${DATADIR}/corrected_final.fa

--- a/example/run_example.sh
+++ b/example/run_example.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#Download this script via "git clone https://github.com/holtjma/fmlrc.git"
+#cd to "fmlrc/examples" and run "./run_example.sh"
+
+#download and build ropebwt2
+if [ ! -f ./ropebwt2/ropebwt2 ]; then
+    git clone https://github.com/lh3/ropebwt2.git
+    cd ropebwt2; make; cd ..
+fi
+
+#download and build fmlrc
+if [ ! -f ../fmlrc ]; then
+    cd ..; make; cd example
+fi
+
+#download short-read ecoli
+if [ ! -f s_6_1.fastq.gz ]; then
+    curl -o s_6_1.fastq.gz http://spades.bioinf.spbau.ru/spades_test_datasets/ecoli_mc/s_6_1.fastq.gz
+fi
+if [ ! -f s_6_2.fastq.gz ]; then
+    curl -o s_6_2.fastq.gz http://spades.bioinf.spbau.ru/spades_test_datasets/ecoli_mc/s_6_2.fastq.gz
+fi
+
+#download long-read ecoli and convert to fasta format
+if [ ! -f PacBioCLR/PacBio_10kb_CLR.fasta ]; then
+    curl -o Ecoli_MG1655_pacBioToCA.tgz http://files.pacb.com/datasets/secondary-analysis/e-coli-k12-de-novo/1.3.0/Ecoli_MG1655_pacBioToCA.tgz
+    tar -xvzf Ecoli_MG1655_pacBioToCA.tgz
+    awk 'NR%4==1||NR%4==2' ./PacBioCLR/PacBio_10kb_CLR.fastq | tr "@" ">" > ./PacBioCLR/PacBio_10kb_CLR.fasta
+fi
+
+#build the bwt
+if [ ! -f ./ecoli_comp_msbwt.npy ]; then
+    mkdir temp
+    gunzip -c s_6_?.fastq.gz | awk "NR % 4 == 2" | sort -T ./temp | tr NT TN | ./ropebwt2/ropebwt2 -LR | tr NT TN | ../fmlrc-convert ./ecoli_comp_msbwt.npy
+fi
+
+#run fmlrc
+NUM_PROCS=4
+../fmlrc -p $NUM_PROCS -V -e 400 ./ecoli_mc_msbwt/comp_msbwt.npy ./PacBioCLR/PacBio_10kb_CLR.fasta ./corrected_final.fa

--- a/example/run_example.sh
+++ b/example/run_example.sh
@@ -36,4 +36,4 @@ fi
 
 #run fmlrc
 NUM_PROCS=4
-../fmlrc -p $NUM_PROCS -V -e 400 ./ecoli_mc_msbwt/comp_msbwt.npy ./PacBioCLR/PacBio_10kb_CLR.fasta ./corrected_final.fa
+../fmlrc -p $NUM_PROCS -V -e 400 ./ecoli_comp_msbwt.npy ./PacBioCLR/PacBio_10kb_CLR.fasta ./corrected_final.fa

--- a/example/run_example.sh
+++ b/example/run_example.sh
@@ -19,11 +19,11 @@ if [ ! -d ${DATADIR} ]; then
 fi
 
 #download short-read ecoli
-if [ ! -f ${DATADIR}/s_6_1.fastq.gz ]; then
-    curl -o ${DATADIR}/s_6_1.fastq.gz http://spades.bioinf.spbau.ru/spades_test_datasets/ecoli_mc/s_6_1.fastq.gz
+if [ ! -f ${DATADIR}/ERR022075_1.fastq.gz ]; then
+    curl -o ${DATADIR}/ERR022075_1.fastq.gz ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR022/ERR022075/ERR022075_1.fastq.gz
 fi
-if [ ! -f ${DATADIR}/s_6_2.fastq.gz ]; then
-    curl -o ${DATADIR}/s_6_2.fastq.gz http://spades.bioinf.spbau.ru/spades_test_datasets/ecoli_mc/s_6_2.fastq.gz
+if [ ! -f ${DATADIR}/ERR022075_2.fastq.gz ]; then
+    curl -o ${DATADIR}/ERR022075_2.fastq.gz ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR022/ERR022075/ERR022075_2.fastq.gz
 fi
 
 #download long-read ecoli and convert to fasta format
@@ -36,7 +36,7 @@ fi
 #build the bwt
 if [ ! -f ${DATADIR}/ecoli_comp_msbwt.npy ]; then
     mkdir temp
-    gunzip -c ${DATADIR}/s_6_?.fastq.gz | awk "NR % 4 == 2" | sort -T ./temp | tr NT TN | ./ropebwt2/ropebwt2 -LR | tr NT TN | ../fmlrc-convert ${DATADIR}/ecoli_comp_msbwt.npy
+    gunzip -c ${DATADIR}/ERR022075_?.fastq.gz | awk "NR % 4 == 2" | sort -T ./temp | tr NT TN | ./ropebwt2/ropebwt2 -LR | tr NT TN | ../fmlrc-convert ${DATADIR}/ecoli_comp_msbwt.npy
 fi
 
 #run fmlrc

--- a/example/run_example.sh
+++ b/example/run_example.sh
@@ -36,4 +36,4 @@ fi
 
 #run fmlrc
 NUM_PROCS=4
-../fmlrc -p $NUM_PROCS -V -e 400 ./ecoli_comp_msbwt.npy ./PacBioCLR/PacBio_10kb_CLR.fasta ./corrected_final.fa
+../fmlrc -p $NUM_PROCS -e 400 ./ecoli_comp_msbwt.npy ./PacBioCLR/PacBio_10kb_CLR.fasta ./corrected_final.fa

--- a/main.cpp
+++ b/main.cpp
@@ -52,7 +52,7 @@ enum {
 };
 const vector<uint8_t> VALID_CHARS = {1, 2, 3, 5};
 
-const string VERSION = "0.1.2";
+const string VERSION = "1.0.0";
 
 uint64_t calculateMedian(vector<uint64_t> inArray, uint64_t minValue) {
     /*


### PR DESCRIPTION
Main change is removing a dependency on _msbwt_ by creating a _fmlrc-convert_ script that is a C++ version of the only thing we were using _msbwt_ for.  Only change to _fmlrc_ core is version number (which I'm taking the opportunity to make a v1.0.0).

@txje can you double check this works on your end before I merge it in?

- [x] Checkout converter-tool branch
- [x] Run `example/run_example.sh`. Verify that the two main outputs (BWT and corrected reads) exist.

I verified the comp_msbwt.npy files are identical on my end for the example and a couple others.  If you have time to double check another example (and compare to `msbwt convert` version) that'd be great, but don't worry about it if you're swamped.